### PR TITLE
BLD: Drop accelerate support on numpy.distutils.system_info level

### DIFF
--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -6,30 +6,7 @@ from distutils.dep_util import newer
 
 
 __all__ = ['needs_g77_abi_wrapper', 'split_fortran_files',
-           'get_g77_abi_wrappers',
-           'uses_veclib', 'uses_accelerate']
-
-
-def uses_veclib(info):
-    if sys.platform != "darwin":
-        return False
-    r_accelerate = re.compile("vecLib")
-    extra_link_args = info.get('extra_link_args', '')
-    for arg in extra_link_args:
-        if r_accelerate.search(arg):
-            return True
-    return False
-
-
-def uses_accelerate(info):
-    if sys.platform != "darwin":
-        return False
-    r_accelerate = re.compile("Accelerate")
-    extra_link_args = info.get('extra_link_args', '')
-    for arg in extra_link_args:
-        if r_accelerate.search(arg):
-            return True
-    return False
+           'get_g77_abi_wrappers']
 
 
 def uses_mkl(info):

--- a/scipy/_build_utils/system_info.py
+++ b/scipy/_build_utils/system_info.py
@@ -1,0 +1,169 @@
+from __future__ import division, absolute_import, print_function
+
+import warnings
+
+import numpy as np
+import numpy.distutils.system_info
+
+from numpy.distutils.system_info import (system_info,
+                                         numpy_info,
+                                         NotFoundError,
+                                         BlasNotFoundError,
+                                         LapackNotFoundError,
+                                         AtlasNotFoundError,
+                                         LapackSrcNotFoundError,
+                                         BlasSrcNotFoundError,
+                                         dict_append,
+                                         get_info as old_get_info)
+
+from scipy._lib._version import NumpyVersion
+
+
+if NumpyVersion(np.__version__) >= "1.15.0.dev":
+    # For new enough numpy.distutils, the ACCELERATE=None environment
+    # variable in the top-level setup.py is enough, so no need to
+    # customize BLAS detection.
+    get_info = old_get_info
+else:
+    # For numpy < 1.15.0, we need overrides.
+
+    def get_info(name, notfound_action=0):
+        # Special case our custom *_opt_info
+        cls = {'lapack_opt': lapack_opt_info,
+               'blas_opt': blas_opt_info}.get(name.lower())
+        if cls is None:
+            return old_get_info(name, notfound_action)
+        return cls().get_info(notfound_action)
+
+
+    #
+    # The following is copypaste from numpy.distutils.system_info, with
+    # OSX Accelerate-related parts removed.
+    #
+
+    class lapack_opt_info(system_info):
+
+        notfounderror = LapackNotFoundError
+
+        def calc_info(self):
+
+            lapack_mkl_info = get_info('lapack_mkl')
+            if lapack_mkl_info:
+                self.set_info(**lapack_mkl_info)
+                return
+
+            openblas_info = get_info('openblas_lapack')
+            if openblas_info:
+                self.set_info(**openblas_info)
+                return
+
+            openblas_info = get_info('openblas_clapack')
+            if openblas_info:
+                self.set_info(**openblas_info)
+                return
+
+            atlas_info = get_info('atlas_3_10_threads')
+            if not atlas_info:
+                atlas_info = get_info('atlas_3_10')
+            if not atlas_info:
+                atlas_info = get_info('atlas_threads')
+            if not atlas_info:
+                atlas_info = get_info('atlas')
+
+            need_lapack = 0
+            need_blas = 0
+            info = {}
+            if atlas_info:
+                l = atlas_info.get('define_macros', [])
+                if ('ATLAS_WITH_LAPACK_ATLAS', None) in l \
+                       or ('ATLAS_WITHOUT_LAPACK', None) in l:
+                    need_lapack = 1
+                info = atlas_info
+
+            else:
+                warnings.warn(AtlasNotFoundError.__doc__, stacklevel=2)
+                need_blas = 1
+                need_lapack = 1
+                dict_append(info, define_macros=[('NO_ATLAS_INFO', 1)])
+
+            if need_lapack:
+                lapack_info = get_info('lapack')
+                #lapack_info = {} ## uncomment for testing
+                if lapack_info:
+                    dict_append(info, **lapack_info)
+                else:
+                    warnings.warn(LapackNotFoundError.__doc__, stacklevel=2)
+                    lapack_src_info = get_info('lapack_src')
+                    if not lapack_src_info:
+                        warnings.warn(LapackSrcNotFoundError.__doc__, stacklevel=2)
+                        return
+                    dict_append(info, libraries=[('flapack_src', lapack_src_info)])
+
+            if need_blas:
+                blas_info = get_info('blas')
+                if blas_info:
+                    dict_append(info, **blas_info)
+                else:
+                    warnings.warn(BlasNotFoundError.__doc__, stacklevel=2)
+                    blas_src_info = get_info('blas_src')
+                    if not blas_src_info:
+                        warnings.warn(BlasSrcNotFoundError.__doc__, stacklevel=2)
+                        return
+                    dict_append(info, libraries=[('fblas_src', blas_src_info)])
+
+            self.set_info(**info)
+            return
+
+
+    class blas_opt_info(system_info):
+
+        notfounderror = BlasNotFoundError
+
+        def calc_info(self):
+
+            blas_mkl_info = get_info('blas_mkl')
+            if blas_mkl_info:
+                self.set_info(**blas_mkl_info)
+                return
+
+            blis_info = get_info('blis')
+            if blis_info:
+                self.set_info(**blis_info)
+                return
+
+            openblas_info = get_info('openblas')
+            if openblas_info:
+                self.set_info(**openblas_info)
+                return
+
+            atlas_info = get_info('atlas_3_10_blas_threads')
+            if not atlas_info:
+                atlas_info = get_info('atlas_3_10_blas')
+            if not atlas_info:
+                atlas_info = get_info('atlas_blas_threads')
+            if not atlas_info:
+                atlas_info = get_info('atlas_blas')
+
+            need_blas = 0
+            info = {}
+            if atlas_info:
+                info = atlas_info
+            else:
+                warnings.warn(AtlasNotFoundError.__doc__, stacklevel=2)
+                need_blas = 1
+                dict_append(info, define_macros=[('NO_ATLAS_INFO', 1)])
+
+            if need_blas:
+                blas_info = get_info('blas')
+                if blas_info:
+                    dict_append(info, **blas_info)
+                else:
+                    warnings.warn(BlasNotFoundError.__doc__, stacklevel=2)
+                    blas_src_info = get_info('blas_src')
+                    if not blas_src_info:
+                        warnings.warn(BlasSrcNotFoundError.__doc__, stacklevel=2)
+                        return
+                    dict_append(info, libraries=[('fblas_src', blas_src_info)])
+
+            self.set_info(**info)
+            return

--- a/scipy/cluster/setup.py
+++ b/scipy/cluster/setup.py
@@ -9,7 +9,7 @@ else:
 
 
 def configuration(parent_package='', top_path=None):
-    from numpy.distutils.system_info import get_info
+    from scipy._build_utils.system_info import get_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     config = Configuration('cluster', parent_package, top_path)
 

--- a/scipy/integrate/setup.py
+++ b/scipy/integrate/setup.py
@@ -8,7 +8,7 @@ from scipy._build_utils import numpy_nodepr_api
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
-    from numpy.distutils.system_info import get_info
+    from scipy._build_utils.system_info import get_info
     config = Configuration('integrate', parent_package, top_path)
 
     # Get a local copy of lapack_opt_info

--- a/scipy/interpolate/setup.py
+++ b/scipy/interpolate/setup.py
@@ -5,7 +5,7 @@ from os.path import join
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
-    from numpy.distutils.system_info import get_info
+    from scipy._build_utils.system_info import get_info
 
     lapack_opt = get_info('lapack_opt', notfound_action=2)
 

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -6,7 +6,7 @@ from os.path import join
 
 def configuration(parent_package='', top_path=None):
     from distutils.sysconfig import get_python_inc
-    from numpy.distutils.system_info import get_info, NotFoundError, numpy_info
+    from scipy._build_utils.system_info import get_info, NotFoundError, numpy_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from scipy._build_utils import (get_g77_abi_wrappers, split_fortran_files)
 

--- a/scipy/odr/setup.py
+++ b/scipy/odr/setup.py
@@ -6,7 +6,7 @@ from os.path import join
 def configuration(parent_package='', top_path=None):
     import warnings
     from numpy.distutils.misc_util import Configuration
-    from numpy.distutils.system_info import get_info, BlasNotFoundError
+    from scipy._build_utils.system_info import get_info, BlasNotFoundError
     config = Configuration('odr', parent_package, top_path)
 
     libodr_files = ['d_odr.f',

--- a/scipy/optimize/_trlib/setup.py
+++ b/scipy/optimize/_trlib/setup.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 def configuration(parent_package='', top_path=None):
     from numpy import get_include
-    from numpy.distutils.system_info import get_info, NotFoundError
+    from scipy._build_utils.system_info import get_info, NotFoundError
     from numpy.distutils.misc_util import Configuration
     
     from os.path import join, dirname

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -6,7 +6,7 @@ from scipy._build_utils import numpy_nodepr_api
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
-    from numpy.distutils.system_info import get_info
+    from scipy._build_utils.system_info import get_info
     config = Configuration('optimize',parent_package, top_path)
 
     minpack_src = [join('minpack','*f')]

--- a/scipy/setup.py
+++ b/scipy/setup.py
@@ -3,14 +3,8 @@ from __future__ import division, print_function, absolute_import
 import sys
 
 def configuration(parent_package='',top_path=None):
-    from numpy.distutils.system_info import get_info, NotFoundError
-    from scipy._build_utils import uses_veclib, uses_accelerate
+    from scipy._build_utils.system_info import get_info, NotFoundError
     lapack_opt = get_info("lapack_opt")
-    if uses_veclib(lapack_opt) or uses_accelerate(lapack_opt):
-        raise NotFoundError(
-            "Using the Accelerate LAPACK implementation "
-            "is no longer supported. A different LAPACK "
-            "implementation is required.")
 
     from numpy.distutils.misc_util import Configuration
     config = Configuration('scipy',parent_package,top_path)

--- a/scipy/sparse/linalg/dsolve/setup.py
+++ b/scipy/sparse/linalg/dsolve/setup.py
@@ -8,7 +8,7 @@ import glob
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
-    from numpy.distutils.system_info import get_info
+    from scipy._build_utils.system_info import get_info
     from scipy._build_utils import numpy_nodepr_api
 
     config = Configuration('dsolve',parent_package,top_path)

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -4,7 +4,7 @@ from os.path import join
 
 
 def configuration(parent_package='',top_path=None):
-    from numpy.distutils.system_info import get_info, NotFoundError
+    from scipy._build_utils.system_info import get_info, NotFoundError
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils import get_g77_abi_wrappers
 

--- a/scipy/sparse/linalg/isolve/setup.py
+++ b/scipy/sparse/linalg/isolve/setup.py
@@ -4,7 +4,7 @@ from os.path import join
 
 
 def configuration(parent_package='',top_path=None):
-    from numpy.distutils.system_info import get_info, NotFoundError
+    from scipy._build_utils.system_info import get_info, NotFoundError
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils import get_g77_abi_wrappers
 

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -7,7 +7,7 @@ import glob
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from numpy.distutils.misc_util import get_info as get_misc_info
-    from numpy.distutils.system_info import get_info as get_sys_info
+    from scipy._build_utils.system_info import get_info as get_sys_info
     from distutils.sysconfig import get_python_inc
 
     config = Configuration('spatial', parent_package, top_path)

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
-    from numpy.distutils.system_info import get_info as get_system_info
+    from scipy._build_utils.system_info import get_info as get_system_info
 
     config = Configuration('special', parent_package, top_path)
 

--- a/setup.py
+++ b/setup.py
@@ -434,6 +434,9 @@ def setup_package():
         # Raise errors for unsupported commands, improve help output, etc.
         run_build = parse_setuppy_commands()
 
+    # Disable OSX Accelerate, it has too old LAPACK
+    os.environ['ACCELERATE'] = 'None'
+
     # This import is here because it needs to be done before importing setup()
     # from numpy.distutils, but after the MANIFEST removing and sdist import
     # higher up in this file.


### PR DESCRIPTION
For detection of BLAS/LAPACK, use our own copies lapack_opt_info and
blas_opt_info which ignore OSX Accelerate.